### PR TITLE
chore(go.mod): updated go.mod go version to 1.21.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/never00rei/go-auth0
 
-go 1.20
+go 1.21
 
 require (
 	github.com/manifoldco/promptui v0.9.0


### PR DESCRIPTION
This PR updates the supported Go version to v1.21. 